### PR TITLE
Fj 2024 lesson 9

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ repositories {
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.1")
     implementation("de.brudaswen.kotlinx.serialization:kotlinx-serialization-csv:2.0.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
 
     implementation("io.ktor:ktor-client-core:$ktorVersion")
     implementation("io.ktor:ktor-client-cio:$ktorVersion")

--- a/src/main/kotlin/ru/tbank/client_2/KudaGoClient.kt
+++ b/src/main/kotlin/ru/tbank/client_2/KudaGoClient.kt
@@ -3,7 +3,6 @@ package ru.tbank.client_2
 import io.ktor.client.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -18,8 +17,8 @@ class KudaGoClient {
     private val httpClient: HttpClient = HttpClient()
     private val json: Json = Json { ignoreUnknownKeys = true }
 
-    private fun get(count: Int, page: Int) = runBlocking {
-        httpClient.get(baseUrl) {
+    private suspend fun get(count: Int, page: Int): HttpResponse {
+        return httpClient.get(baseUrl) {
             parameter("page", page.toString())
             parameter("page_size", count)
             parameter("order_by", "publication_date")
@@ -32,27 +31,30 @@ class KudaGoClient {
         }
     }
 
-    fun getNews(count: Int = 100, page: Int = 1): List<News> {
+    suspend fun getNews(count: Int = 10, page: Int = 1): List<News> {
         if (count > 100)
             throw IllegalArgumentException("Cannot load more than 100 news")
 
-        val response: HttpResponse = runCatching { get(count, page) }
-            .onFailure { logger.error(it.message) }
-            .getOrNull()
-            ?: return emptyList()
+        var result: List<News> = emptyList()
 
-        logger.info("Get info from KudaGo API")
-        logger.info("Trying to parse json from KudaGo API...")
+        try {
+            val response: HttpResponse = get(count, page);
 
-        val result: List<News> = runBlocking {
-            json.parseToJsonElement(response.bodyAsText()).jsonObject["results"]
+            logger.info("Get info from KudaGo API")
+            logger.info("Trying to parse json from KudaGo API...")
+
+            result = json
+                .parseToJsonElement(response.bodyAsText()).jsonObject["results"]
                 ?.jsonArray
                 ?.map { it.jsonObject }
                 ?.map { json.decodeFromString(it.toString()) }
                 ?: emptyList()
-        }
 
-        logger.info("Json successfully parsed")
+            logger.info("Json successfully parsed")
+        } catch (exc: Exception) {
+            logger.warn("Failed to gather news from Kudago")
+            logger.warn(exc.message)
+        }
 
         return result
     }

--- a/src/main/kotlin/ru/tbank/client_2/KudaGoClient.kt
+++ b/src/main/kotlin/ru/tbank/client_2/KudaGoClient.kt
@@ -38,7 +38,7 @@ class KudaGoClient {
         var result: List<News> = emptyList()
 
         try {
-            val response: HttpResponse = get(count, page);
+            val response: HttpResponse = get(count, page)
 
             logger.info("Get info from KudaGo API")
             logger.info("Trying to parse json from KudaGo API...")

--- a/src/main/kotlin/ru/tbank/coroutines/CoroutinesExample.kt
+++ b/src/main/kotlin/ru/tbank/coroutines/CoroutinesExample.kt
@@ -1,0 +1,68 @@
+package ru.tbank.coroutines
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.newFixedThreadPoolContext
+import kotlinx.coroutines.runBlocking
+import ru.tbank.client_2.KudaGoClient
+import ru.tbank.dto_1.News
+import ru.tbank.saving_4.NewsCsvSaver
+import java.nio.file.Path
+
+
+fun main() {
+    val pagesNumber = 4
+
+    blockingExample(pagesNumber)
+    coroutineExample(pagesNumber, 2)
+    coroutineExample(pagesNumber, 4)
+    coroutineExample(pagesNumber, 8)
+}
+
+fun blockingExample(pagesNumber: Int) {
+    val client = KudaGoClient()
+    val saver = NewsCsvSaver(Path.of("dump.csv"))
+
+    val startTime = System.nanoTime()
+
+    for (i in 1..pagesNumber) {
+        val res = runBlocking { client.getNews(10, i + 1) }
+        saver.saveNews(res)
+    }
+
+    val endTime = System.nanoTime()
+
+    println("Time for gathering $pagesNumber pages in blocking way is ${endTime - startTime}ns")
+}
+
+fun coroutineExample(pagesNumber: Int, threadsNumber: Int) {
+    val threadPoolContext = newFixedThreadPoolContext(threadsNumber, "coroutine-pool")
+
+    val channel = Channel<List<News>>()
+    val newsProducer = NewsProducer()
+    val newsConsumer = NewsConsumer(Path.of("dump.csv"))
+
+    val startTime = System.nanoTime()
+
+    runBlocking {
+        launch {
+            newsConsumer.saveNews(channel)
+        }
+
+        coroutineScope {
+            repeat(pagesNumber) {
+                launch(threadPoolContext) {
+                    newsProducer.getNews(10, it + 1, channel)
+                }
+            }
+        }
+
+        channel.close()
+    }
+
+    val endTime = System.nanoTime()
+
+    println("Time for gathering $pagesNumber pages with $threadsNumber threads with coroutines is ${endTime - startTime}ns")
+}
+

--- a/src/main/kotlin/ru/tbank/coroutines/CoroutinesExample.kt
+++ b/src/main/kotlin/ru/tbank/coroutines/CoroutinesExample.kt
@@ -27,7 +27,7 @@ fun blockingExample(pagesNumber: Int) {
     val startTime = System.nanoTime()
 
     for (i in 1..pagesNumber) {
-        val res = runBlocking { client.getNews(10, i + 1) }
+        val res = runBlocking { client.getNews(100, i + 1) }
         saver.saveNews(res)
     }
 
@@ -53,7 +53,7 @@ fun coroutineExample(pagesNumber: Int, threadsNumber: Int) {
         coroutineScope {
             repeat(pagesNumber) {
                 launch(threadPoolContext) {
-                    newsProducer.getNews(10, it + 1, channel)
+                    newsProducer.getNews(100, it + 1, channel)
                 }
             }
         }

--- a/src/main/kotlin/ru/tbank/coroutines/NewsConsumer.kt
+++ b/src/main/kotlin/ru/tbank/coroutines/NewsConsumer.kt
@@ -1,0 +1,20 @@
+package ru.tbank.coroutines
+
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.coroutineScope
+import ru.tbank.dto_1.News
+import ru.tbank.saving_4.NewsCsvSaver
+import java.nio.file.Path
+
+class NewsConsumer(filepath: Path) {
+
+    private val csvSaver: NewsCsvSaver = NewsCsvSaver(filepath)
+
+    suspend fun saveNews(channel: ReceiveChannel<List<News>>) {
+        coroutineScope {
+            channel.consumeEach { news -> csvSaver.saveNews(news) }
+        }
+        csvSaver.close()
+    }
+}

--- a/src/main/kotlin/ru/tbank/coroutines/NewsProducer.kt
+++ b/src/main/kotlin/ru/tbank/coroutines/NewsProducer.kt
@@ -1,0 +1,15 @@
+package ru.tbank.coroutines
+
+import kotlinx.coroutines.channels.SendChannel
+import ru.tbank.client_2.KudaGoClient
+import ru.tbank.dto_1.News
+
+class NewsProducer {
+
+    private val client = KudaGoClient()
+
+    suspend fun getNews(count: Int, page: Int, channel: SendChannel<List<News>>) {
+        val news = client.getNews(count = count, page = page)
+        channel.send(news)
+    }
+}

--- a/src/main/kotlin/ru/tbank/filtering_2/NewsFilter.kt
+++ b/src/main/kotlin/ru/tbank/filtering_2/NewsFilter.kt
@@ -9,7 +9,7 @@ class NewsFilter {
 
     private val client = KudaGoClient()
 
-    fun getMostRatedNews(count: Int, period: ClosedRange<LocalDate>): List<News> {
+    suspend fun getMostRatedNews(count: Int, period: ClosedRange<LocalDate>): List<News> {
         var pageIndex: Int = 1
         val news: MutableList<News> = ArrayList()
         var currentBatch: List<News> = client.getNews(count = 100, page = pageIndex++)

--- a/src/main/kotlin/ru/tbank/saving_4/SaveNews.kt
+++ b/src/main/kotlin/ru/tbank/saving_4/SaveNews.kt
@@ -5,25 +5,31 @@ import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.csv.Csv
 import org.slf4j.LoggerFactory
 import ru.tbank.dto_1.News
-import java.io.File
 import java.io.IOException
+import java.io.PrintWriter
+import java.nio.file.Path
 
-class NewsCsvSaver {
+class NewsCsvSaver(private val filepath: Path) {
 
     @OptIn(ExperimentalSerializationApi::class)
     private val csv = Csv { hasHeaderRecord = true }
+    private val writer: PrintWriter = PrintWriter(filepath.toFile())
 
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     @OptIn(ExperimentalSerializationApi::class)
-    fun saveNews(path: String, news: List<News>) {
+    fun saveNews(news: List<News>) {
         val serialized = csv.encodeToString(ListSerializer(News.serializer()), news)
 
         try {
-            File(path).writeText(serialized)
+            writer.write(serialized)
         } catch (e: IOException) {
-            logger.error("Error while saving news in file $path", e)
+            logger.error("Error while saving news in file $filepath", e)
         }
+    }
+
+    fun close() {
+        writer.close()
     }
 
 }


### PR DESCRIPTION
Использование корутин ускоряет выполнение запросов в 2 раза. Причем количество потоков в тред пуле большой роли не играет. В тредпуле на 8 потоков время выполнения получилось даже больше чем при 4 потоках.
![image](https://github.com/user-attachments/assets/6c15d71b-6610-4aea-bbc6-6159b027732b)


Возможно, если указать количество страниц больше, то результаты будут более явные. Однако KudaGO ограничивает количество запросов и выкидывает такую страницу вместо ответа
![image](https://github.com/user-attachments/assets/7cc2a9b6-0a36-4e89-b867-478fa6ad2278)
